### PR TITLE
FIX build on windows (mingw)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@
 # -----------------------------------------------------------------------
 
 JAVA = java
-JAVAC = javac -source 16
+JAVAC = javac -encoding UTF8 -source 16
 FZ_SRC = $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 SRC = $(FZ_SRC)/src
 BUILD_DIR = ./build
@@ -369,13 +369,15 @@ $(BUILD_DIR)/bin/fzjava: $(FZ_SRC)/bin/fzjava $(CLASS_FILES_TOOLS_FZJAVA)
 $(MOD_JAVA_BASE): $(BUILD_DIR)/bin/fzjava
 	rm -rf $(@D)
 	mkdir -p $(@D)
-	$(BUILD_DIR)/bin/fzjava java.base -to=$(@D) -verbose=0
+# wrapping in /bin/bash -c "..." is a workaround for building on windows, bash (mingw)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.base -to=$(@D) -verbose=0"
 	touch $@
 
 $(MOD_JAVA_XML): $(BUILD_DIR)/bin/fzjava
 	rm -rf $(@D)
 	mkdir -p $(@D)
-	$(BUILD_DIR)/bin/fzjava java.xml -to=$(@D) -verbose=0
+# wrapping in /bin/bash -c "..." is a workaround for building on windows, bash (mingw)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.xml -to=$(@D) -verbose=0"
 	# NYI: manually delete redundant features
 	rm -f $(BUILD_DIR)/modules/java.xml/Java_pkg.fz
 	rm -f $(BUILD_DIR)/modules/java.xml/Java/jdk_pkg.fz
@@ -387,7 +389,8 @@ $(MOD_JAVA_XML): $(BUILD_DIR)/bin/fzjava
 $(MOD_JAVA_DATATRANSFER): $(BUILD_DIR)/bin/fzjava
 	rm -rf $(@D)
 	mkdir -p $(@D)
-	$(BUILD_DIR)/bin/fzjava java.datatransfer -to=$(@D) -verbose=0
+# wrapping in /bin/bash -c "..." is a workaround for building on windows, bash (mingw)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.datatransfer -to=$(@D) -verbose=0"
 	# NYI: manually delete redundant features
 	rm -f $(BUILD_DIR)/modules/java.datatransfer/Java_pkg.fz
 	rm -f $(BUILD_DIR)/modules/java.datatransfer/Java/java_pkg.fz
@@ -398,7 +401,8 @@ $(MOD_JAVA_DATATRANSFER): $(BUILD_DIR)/bin/fzjava
 $(MOD_JAVA_DESKTOP): $(BUILD_DIR)/bin/fzjava
 	rm -rf $(@D)
 	mkdir -p $(@D)
-	$(BUILD_DIR)/bin/fzjava java.desktop -to=$(@D) -verbose=0
+# wrapping in /bin/bash -c "..." is a workaround for building on windows, bash (mingw)
+	/bin/bash -c "$(BUILD_DIR)/bin/fzjava java.desktop -to=$(@D) -verbose=0"
 	# NYI: manually delete redundant features
 	rm -f $(BUILD_DIR)/modules/java.desktop/Java_pkg.fz
 	rm -f $(BUILD_DIR)/modules/java.desktop/Java/javax_pkg.fz

--- a/src/dev/flang/fe/FrontEnd.java
+++ b/src/dev/flang/fe/FrontEnd.java
@@ -318,6 +318,7 @@ public class FrontEnd extends ANY
     // find fuzion home via classes directory:
     String p = new File(FrontEnd.class.getProtectionDomain().getCodeSource().getLocation().getPath())
       .getAbsolutePath()
+      // NYI properly decode all special characters in paths
       .replace("%20", " ");
 
     FUZION_HOME = Path.of(p).getParent();

--- a/src/dev/flang/fe/FrontEnd.java
+++ b/src/dev/flang/fe/FrontEnd.java
@@ -316,19 +316,10 @@ public class FrontEnd extends ANY
     CURRENT_DIRECTORY = Path.of(".");
 
     // find fuzion home via classes directory:
-    Class<FrontEnd> cl = FrontEnd.class;
-    String clname = cl.getName().replace(".",File.separator)+ ".class";
-    var url = FrontEnd.class.getClassLoader().getResource(clname);
-    String p;
-    try
-      { // convert to URI to remove URL encoded chars ('%20' -> ' ')
-        p = new URI(url.toString()).getPath();
-      }
-    catch (URISyntaxException e)  // when could this happen?
-      {
-        p = url.getPath();  // as long as there are no URLEncoded chars, this should do as a fallback
-      }
-    p = p.substring(0, p.length() - clname.length());
+    String p = new File(FrontEnd.class.getProtectionDomain().getCodeSource().getLocation().getPath())
+      .getAbsolutePath()
+      .replace("%20", " ");
+
     FUZION_HOME = Path.of(p).getParent();
 
     SOURCE_PATHS = new Path[] { FUZION_HOME.resolve("lib"), CURRENT_DIRECTORY };


### PR DESCRIPTION
- javac, force utf8 encoding of source files
- workaround for error when calling fzjava from Makefile
- changed algorithm for finding fuzion home dir via FrontEnd.class file