### PR TITLE
Pretty.print(): iterate source file by codepoints not by bytes

### DIFF
--- a/src/dev/flang/tools/Pretty.java
+++ b/src/dev/flang/tools/Pretty.java
@@ -26,6 +26,7 @@ Fuzion language implementation.  If not, see <https://www.gnu.org/licenses/>.
 
 package dev.flang.tools;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
 import dev.flang.parser.Lexer;
@@ -125,7 +126,7 @@ public class Pretty extends ANY
   {
     Styler s = new TerminalStyler();
     var style = s.plain();
-    for (int j = 0; j < f.byteLength(); j++)
+    for (int j = 0; j < f.byteLength(); j = j + f.codePointSize(j))
       {
         var t = i.get(j);
         var newStyle = style(s, t);
@@ -135,7 +136,9 @@ public class Pretty extends ANY
             style = newStyle;
             System.out.print(style.start());
           }
-        System.out.write(f.byteAt(j));
+        byte[] codePointBytes = f.bytesAt(j);
+        String codePoint = new String(codePointBytes, StandardCharsets.UTF_8);
+        System.out.print(codePoint);
       }
     System.out.print(style.end());
   }

--- a/src/dev/flang/util/SourceFile.java
+++ b/src/dev/flang/util/SourceFile.java
@@ -897,6 +897,22 @@ public class SourceFile extends ANY
     return _bytes[i];
   }
 
+   /**
+   * Get bytes of codepoint starting at the given position
+   *
+   * @param pos an index in the file
+   *
+   * @return the byte[] at given index
+   */
+  public byte[] bytesAt(int pos) {
+    var codePointSize = codePointSize(pos);
+    byte[] result = new byte[codePointSize];
+    for (int i = 0; i < codePointSize; i++) {
+      result[i] = byteAt(pos+i);
+    }
+    return result;
+  }
+
 }
 
 /* end of file */


### PR DESCRIPTION
fixes pretty printing of files with utf8-chars like this one: ∘ 